### PR TITLE
Update to 0.22.1, add myself to maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @bandersen23
+* @bandersen23 @dbast

--- a/README.md
+++ b/README.md
@@ -148,4 +148,5 @@ Feedstock Maintainers
 =====================
 
 * [@bandersen23](https://github.com/bandersen23/)
+* [@dbast](https://github.com/dbast/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ build:
 
 requirements:
   host:
-    - pip <22
     - python >=3.7
     - pdm
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ build:
 requirements:
   host:
     - python >=3.7
-    - pdm
+    - pdm >2
   run:
     - python >=3.7
     - cached-property
@@ -48,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - bandersen23
+    - dbast

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "griffe" %}
-{% set version = "0.22.0" %}
+{% set version = "0.22.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/griffe-{{ version }}.tar.gz
-  sha256: a3c25a2b7bf729ecee7cd455b4eff548f01c620b8f58a8097a800caad221f12e
+  sha256: 0130019b0b3966e9d755d9acb82fe9b64e354064ce971306e5892c098bf1a5c7
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - griffe = griffe.cli:main


### PR DESCRIPTION
Contains this PR https://github.com/conda-forge/griffe-feedstock/pull/33 and adds on top to fix `ModuleNotFoundError: No module named 'pip._vendor.html5lib'` during build.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
