### PR TITLE
Provide old 0.21.0 version as noarch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "griffe" %}
-{% set version = "0.22.1" %}
+{% set version = "0.21.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/griffe-{{ version }}.tar.gz
-  sha256: 0130019b0b3966e9d755d9acb82fe9b64e354064ce971306e5892c098bf1a5c7
+  sha256: 61ab3bc02b09afeb489f1aef44c646a09f1837d9cdf15943ac6021903a4d3984
 
 build:
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - griffe = griffe.cli:main


### PR DESCRIPTION
Provide old 0.21.0 version as noarch, as packages like prefect 2 need an older version be available on many platforms. The griffe package was only made noarch beginning from version 0.22.0. This PR is targeting the main-0.21.0 branch (derived from current main branch) instead of the main branch, to not confuse the regro-bot, which proposes updates. 

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
